### PR TITLE
Fix swarmers reappearing when inside cargo mech

### DIFF
--- a/Bots'n'Bugs/scripts/doubleSpawn.lua
+++ b/Bots'n'Bugs/scripts/doubleSpawn.lua
@@ -101,6 +101,7 @@ function Mission.GetSpawnCount(...)
 	for i = 1, math.ceil(#pawns / 2) do
 		local swarmer = pawns[i]
 		Board:AddPawn(swarmer.pawn, swarmer.loc)
+		swarmer.pawn:SetSpace(swarmer.loc)
 	end
 	
 	return result


### PR DESCRIPTION
Cargo mech stores units by setting their space to -1,-1, but when Bots'n'Bugs does its half spawn check, it removes and readds half of the swarmers. The swarmer is readded at its old space, however vanilla interprets -1,-1 as "random space". This fix simply adds a redundant space setting as `SetSpace` allows -1,-1